### PR TITLE
correct copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 LocationIQ
+Copyright (c) 2018 Mapzen, LocationIQ
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Eight of the top ten contributors to this project are not being credited for copyright ownership of their contributions.
Forking the repository does not give you the legal right to change the copyright ownership of its authors.

The MIT license very generously allows you to copy the work and to use it commercially, it is, however, illegal to claim copyright over works created by others without their explicit consent.

Please be more careful in the future, just because Mapzen shut down doesn't mean that its copyright works are now public domain.

You are, however, as always, free to use the software according to the very generous conditions afforded by the works being published under the MIT license.